### PR TITLE
Set explicit read permissions for test workflow

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -3,6 +3,8 @@ on: pull_request
 jobs:
   test:
     name: test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       # ...


### PR DESCRIPTION
Explicitly define "contents: read" permission for the test job to follow security best practices and the principle of least privilege.
