### PR TITLE
Implement Discord Components V2 for tournament match messages

### DIFF
--- a/apps/discord/package.json
+++ b/apps/discord/package.json
@@ -28,7 +28,7 @@
         "reflect-metadata": "catalog:reflection"
     },
     "scripts": {
-        "dev": "bun ./src/index.ts",
+        "dev": "bun run src/index.ts",
         "build": "tsc",
         "lint": "eslint .",
         "start": "bun run dist/index.js"

--- a/apps/discord/src/commands/root/connect.ts
+++ b/apps/discord/src/commands/root/connect.ts
@@ -31,8 +31,10 @@ export class ConnectCommand extends Command {
     interaction: Command.ChatInputCommandInteraction,
   ) {
     await interaction.deferReply();
-    const channelId = BigInt(interaction.channelId);
-    const result = await this._connectionService.connect(channelId);
+    const result = await this._connectionService.connect(
+      interaction.channelId,
+      interaction.guildId!,
+    );
     switch (result) {
       case ConnectionResult.Success: {
         await interaction.editReply(

--- a/apps/discord/src/commands/root/disconnect.ts
+++ b/apps/discord/src/commands/root/disconnect.ts
@@ -31,8 +31,9 @@ export class DisconnectCommand extends Command {
     interaction: Command.ChatInputCommandInteraction,
   ) {
     await interaction.deferReply();
-    const channelId = BigInt(interaction.channelId);
-    const result = await this._connectionService.disconnect(channelId);
+    const result = await this._connectionService.disconnect(
+      interaction.channelId,
+    );
     switch (result) {
       case DisconnectionResult.Success: {
         await interaction.editReply(

--- a/apps/discord/src/commands/root/language.ts
+++ b/apps/discord/src/commands/root/language.ts
@@ -61,9 +61,8 @@ export class SetPreferredLanguageCommand extends Command {
       return;
     }
 
-    const channelId = BigInt(interaction.channelId);
     const result = await this.configurationService.setPreferredLanguage(
-      channelId,
+      interaction.channelId,
       language,
     );
     switch (result) {

--- a/apps/discord/src/commands/root/timezone.ts
+++ b/apps/discord/src/commands/root/timezone.ts
@@ -61,9 +61,8 @@ export class SetTimezone extends Command {
       return;
     }
 
-    const channelId = BigInt(interaction.channelId);
     const result = await this.configurationService.setNotificationTimezone(
-      channelId,
+      interaction.channelId,
       timezone,
     );
     switch (result) {

--- a/apps/discord/src/commands/root/today.ts
+++ b/apps/discord/src/commands/root/today.ts
@@ -45,16 +45,15 @@ export class TodayCommand extends Command {
   ) {
     await interaction.deferReply();
 
-    const channelId = BigInt(interaction.channelId);
-
     const result = await this.tournamentService.getTournamentsWithMatchesToday(
-      channelId,
+      interaction.channelId,
       "Midnight",
     );
     switch (result.status) {
       case GetTournamentsWithMatchesTodayResultStatus.Success: {
-        const channelConfig =
-          await this.configurationService.getConfiguration(channelId);
+        const channelConfig = await this.configurationService.getConfiguration(
+          interaction.channelId,
+        );
 
         const containers = this.tournamentMessageBuilder.build(
           channelConfig!,

--- a/apps/discord/src/commands/root/today.ts
+++ b/apps/discord/src/commands/root/today.ts
@@ -7,7 +7,7 @@ import { Symbols as SharedSymbols } from "@dotabot.js/shared/Symbols";
 import { ApplicationCommandRegistry, Command } from "@sapphire/framework";
 import { botContainer } from "../../di/container";
 import { Symbols } from "../../di/symbols";
-import { channelMention } from "discord.js";
+import { channelMention, MessageFlags } from "discord.js";
 import { TournamentEmbedMessageBuilder } from "../../message/TournamentEmbedMessageBuilder";
 
 export class TodayCommand extends Command {
@@ -56,17 +56,23 @@ export class TodayCommand extends Command {
         const channelConfig =
           await this.configurationService.getConfiguration(channelId);
 
-        const embeds = this.tournamentMessageBuilder.build(
+        const containers = this.tournamentMessageBuilder.build(
           channelConfig!,
           result.data,
         );
 
-        for (const embed of embeds) {
+        for (const container of containers) {
           // If we've not replied yet, reply now, and follow up the rest
           if (!interaction.replied) {
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.editReply({
+              components: [container],
+              flags: MessageFlags.IsComponentsV2,
+            });
           } else {
-            await interaction.followUp({ embeds: [embed] });
+            await interaction.followUp({
+              components: [container],
+              flags: MessageFlags.IsComponentsV2,
+            });
           }
         }
 

--- a/apps/discord/src/commands/tier/tier.ts
+++ b/apps/discord/src/commands/tier/tier.ts
@@ -94,9 +94,10 @@ export class TierCommand extends Subcommand {
       return;
     }
 
-    const channelId = BigInt(interaction.channelId);
-
-    const result = await this._configurationService.addTier(channelId, tier);
+    const result = await this._configurationService.addTier(
+      interaction.channelId,
+      tier,
+    );
     switch (result) {
       case AddTierResult.Success: {
         await interaction.editReply(
@@ -136,9 +137,10 @@ export class TierCommand extends Subcommand {
       return;
     }
 
-    const channelId = BigInt(interaction.channelId);
-
-    const result = await this._configurationService.removeTier(channelId, tier);
+    const result = await this._configurationService.removeTier(
+      interaction.channelId,
+      tier,
+    );
     switch (result) {
       case RemoveTierResult.Success: {
         await interaction.editReply(

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -1,9 +1,21 @@
-import { SapphireClient } from "@sapphire/framework";
+import {
+  ApplicationCommandRegistries,
+  RegisterBehavior,
+  SapphireClient,
+} from "@sapphire/framework";
 import { GatewayIntentBits } from "discord.js";
 
 const discordToken = process.env.DISCORD_TOKEN;
 if (!discordToken) {
   throw new Error("No Discord token provided");
+}
+
+const guildId = process.env.GUILD_ID;
+if (guildId) {
+  ApplicationCommandRegistries.setDefaultGuildIds([guildId]);
+  ApplicationCommandRegistries.setDefaultBehaviorWhenNotIdentical(
+    RegisterBehavior.BulkOverwrite,
+  );
 }
 
 const client = new SapphireClient({

--- a/apps/discord/src/listeners/guildDelete.ts
+++ b/apps/discord/src/listeners/guildDelete.ts
@@ -1,0 +1,25 @@
+import { Listener } from "@sapphire/framework";
+import type { Guild } from "discord.js";
+import { botContainer } from "../di/container";
+import { Symbols } from "@dotabot.js/shared/Symbols";
+import type { ConnectionService } from "@dotabot.js/domain/service/ConnectionService";
+
+export class GuildDeleteListener extends Listener {
+  private readonly connectionService: ConnectionService;
+
+  constructor(context: Listener.LoaderContext, options: Listener.Options) {
+    super(context, {
+      ...options,
+      event: "guildDelete",
+    });
+
+    this.connectionService = botContainer.get<ConnectionService>(
+      Symbols.ConnectionService,
+    );
+  }
+
+  async run(guild: Guild) {
+    console.log(`Bot has been removed from guild ${guild.name} - ${guild.id}`);
+    await this.connectionService.disconnectAll(guild.id);
+  }
+}

--- a/apps/discord/src/message/TournamentEmbedMessageBuilder.ts
+++ b/apps/discord/src/message/TournamentEmbedMessageBuilder.ts
@@ -6,16 +6,17 @@ import type { TournamentIteration } from "@dotabot.js/domain/data/TournamentIter
 import type { TournamentPhase } from "@dotabot.js/domain/data/TournamentPhase";
 import type { StreamSelector } from "@dotabot.js/domain/selector/StreamSelector";
 import {
-  EmbedBuilder,
+  ContainerBuilder,
   hyperlink,
+  SeparatorSpacingSize,
   time,
   TimestampStyles,
-  type ColorResolvable,
+  type RGBTuple,
 } from "discord.js";
 import { injectable, inject } from "inversify";
 import { Symbols } from "@dotabot.js/shared/Symbols";
 
-const EmbedColor: ColorResolvable = "DarkAqua";
+const AccentColour: RGBTuple | number = 4688544;
 
 @injectable()
 export class TournamentEmbedMessageBuilder {
@@ -26,29 +27,36 @@ export class TournamentEmbedMessageBuilder {
   build(
     channelConfig: ChannelConfiguration,
     tournaments: Tournament[],
-  ): EmbedBuilder[] {
-    const embeds: EmbedBuilder[] = [];
+  ): ContainerBuilder[] {
+    const containers: ContainerBuilder[] = [];
     for (const tournament of tournaments) {
       for (const iteration of tournament.iterations) {
         for (const phase of iteration.phases) {
-          const embed = this.buildTournamentMessage(
+          const container = this.buildTournamentMessage(
             channelConfig,
             tournament,
             iteration,
             phase,
           );
-          if (!embed) continue;
+          if (!container) continue;
 
-          embeds.push(embed);
+          containers.push(container);
         }
       }
     }
 
     // If there's no embeds, there's no matches to report, at least push a "No matches today!" embed
-    if (embeds.length === 0) {
-      embeds.push(new EmbedBuilder().setTitle(":robot: No matches today!"));
+    if (containers.length === 0) {
+      containers.push(
+        new ContainerBuilder()
+          .setAccentColor(AccentColour)
+          .addTextDisplayComponents((text) =>
+            text.setContent("No matches today!"),
+          ),
+      );
     }
-    return embeds;
+
+    return containers;
   }
 
   buildTournamentMessage(
@@ -56,7 +64,7 @@ export class TournamentEmbedMessageBuilder {
     tournament: Tournament,
     iteration: TournamentIteration,
     phase: TournamentPhase,
-  ): EmbedBuilder | undefined {
+  ): ContainerBuilder | undefined {
     if (phase.matches.length === 0) {
       return;
     }
@@ -67,26 +75,55 @@ export class TournamentEmbedMessageBuilder {
     }
 
     const title = this.getTournamentTitle(tournament, iteration, phase);
-    const builder = new EmbedBuilder()
-      .setTitle(`:robot: ${title} games today!`)
-      .setColor(EmbedColor)
-      .setDescription(
-        `Tournament data provided by ${hyperlink("PandaScore", "https://www.pandascore.co/")}`,
+    let builder = new ContainerBuilder()
+      .setAccentColor(AccentColour)
+      .addSectionComponents(
+        (section) =>
+          section.addTextDisplayComponents((text) =>
+            text.setContent(`### :robot: ${title} matches today!`),
+          ),
+        // TODO: Add back in when adding match notifications
+        // .setButtonAccessory((button) =>
+        //   button
+        //     .setCustomId(`${phase.id}`)
+        //     .setLabel("Notify me!")
+        //     .setStyle(ButtonStyle.Success)
+        //     .setEmoji({ name: "🔔" }),
+        // ),
+      )
+      .addSeparatorComponents((separator) =>
+        separator.setDivider(false).setSpacing(SeparatorSpacingSize.Small),
       );
 
     // key = stream URL
     // value = matches array
     for (const [key, value] of matches) {
-      builder.addFields({
-        name: `Matches on ${key}`,
-        value: value
-          .map(
-            (match) =>
-              `${time(match.scheduledAt.toJSDate(), TimestampStyles.ShortTime)} - ${this.getOpponentName(match.radiant)} vs ${this.getOpponentName(match.dire)}`,
-          )
-          .join("\n"),
-      });
+      builder = builder
+        .addTextDisplayComponents((text) =>
+          text.setContent(`### Matches on ${key}`),
+        )
+        .addTextDisplayComponents((text) =>
+          text.setContent(
+            value
+              .map(
+                (match) =>
+                  `${time(match.scheduledAt.toJSDate(), TimestampStyles.ShortTime)} - ${this.getOpponentName(match.radiant)} vs ${this.getOpponentName(match.dire)}`,
+              )
+              .join("\n"),
+          ),
+        )
+        .addSeparatorComponents((separator) =>
+          separator.setDivider(true).setSpacing(SeparatorSpacingSize.Small),
+        );
     }
+
+    builder = builder.addTextDisplayComponents((text) =>
+      text.setContent(
+        `Tournament data provided by ${hyperlink("PandaScore", "https://pandascore.co/")}`,
+      ),
+    );
+
+    // console.log(builder.toJSON());
 
     return builder;
   }

--- a/apps/discord/src/messenger/DailyMatchesMessengerImpl.ts
+++ b/apps/discord/src/messenger/DailyMatchesMessengerImpl.ts
@@ -5,6 +5,7 @@ import { container } from "@sapphire/framework";
 import { Symbols } from "../di/symbols";
 import { inject } from "inversify";
 import type { TournamentEmbedMessageBuilder } from "../message/TournamentEmbedMessageBuilder";
+import { MessageFlags } from "discord.js";
 
 export class DailyMatchesMessengerImpl implements DailyMatchesMessenger {
   constructor(
@@ -23,14 +24,15 @@ export class DailyMatchesMessengerImpl implements DailyMatchesMessenger {
       return;
     }
 
-    const embeds = this.tournamentMessageBuilder.build(
+    const containers = this.tournamentMessageBuilder.build(
       channelConfig,
       tournaments,
     );
 
-    for (const embed of embeds) {
+    for (const container of containers) {
       await channel.send({
-        embeds: [embed],
+        components: [container],
+        flags: MessageFlags.IsComponentsV2,
       });
     }
   }

--- a/packages/application/src/caches/ChannelConfigurationCacheImpl.ts
+++ b/packages/application/src/caches/ChannelConfigurationCacheImpl.ts
@@ -12,12 +12,13 @@ export class ChannelConfigurationCacheImpl implements ChannelConfigurationCache 
     @inject(Symbols.Cache) private readonly cache: LRUCache<string, string>,
   ) {}
 
-  get(channelId: bigint): ChannelConfiguration | undefined {
+  get(channelId: string): ChannelConfiguration | undefined {
     function parse(json: string): ChannelConfiguration {
       // TODO: Maybe have some kind of DTO type for better error handling
       const obj = JSON.parse(json);
       return new ChannelConfiguration(
-        BigInt(obj.channelId),
+        obj.channelId,
+        obj.serverId,
         obj.tiers,
         obj.timezone,
         obj.preferredLanguage,
@@ -26,7 +27,7 @@ export class ChannelConfigurationCacheImpl implements ChannelConfigurationCache 
       );
     }
 
-    const channelConfigJson = this.cache.get(channelId.toString());
+    const channelConfigJson = this.cache.get(channelId);
     if (!channelConfigJson) {
       return;
     }
@@ -35,13 +36,14 @@ export class ChannelConfigurationCacheImpl implements ChannelConfigurationCache 
   }
 
   set(
-    channelId: bigint,
+    channelId: string,
     channelConfig: ChannelConfiguration,
     ttl?: number,
   ): void {
     function serialise(config: ChannelConfiguration): string {
       return JSON.stringify({
-        channelId: config.channelId.toString(),
+        channelId: config.channelId,
+        serverId: config.serverId,
         tiers: config.tiers,
         timezone: config.timezone,
         preferredLanguage: config.preferredLanguage,
@@ -50,12 +52,12 @@ export class ChannelConfigurationCacheImpl implements ChannelConfigurationCache 
       });
     }
     const json = serialise(channelConfig);
-    this.cache.set(channelId.toString(), json, {
+    this.cache.set(channelId, json, {
       ttl: ttl ?? DefaultTTL,
     });
   }
 
-  delete(channelId: bigint): void {
-    this.cache.delete(channelId.toString());
+  delete(channelId: string): void {
+    this.cache.delete(channelId);
   }
 }

--- a/packages/application/src/repositories/CachedChannelConfigurationRepository.ts
+++ b/packages/application/src/repositories/CachedChannelConfigurationRepository.ts
@@ -53,6 +53,11 @@ export class CachedChannelConfigurationRepository implements ChannelConfiguratio
     return result;
   }
 
+  async deleteByServerId(serverId: string): Promise<boolean> {
+    // TODO: Update cache and remove deleted channel configurations
+    return this.repository.deleteByServerId(serverId);
+  }
+
   delete(id: number): Promise<boolean> {
     return this.repository.delete(id);
   }

--- a/packages/application/src/repositories/CachedChannelConfigurationRepository.ts
+++ b/packages/application/src/repositories/CachedChannelConfigurationRepository.ts
@@ -14,7 +14,7 @@ export class CachedChannelConfigurationRepository implements ChannelConfiguratio
   ) {}
 
   async getByChannelId(
-    channelId: bigint,
+    channelId: string,
   ): Promise<ChannelConfiguration | undefined> {
     let channelConfig = this.cache.get(channelId);
     if (!channelConfig) {
@@ -45,7 +45,7 @@ export class CachedChannelConfigurationRepository implements ChannelConfiguratio
     return this.repository.update(id, entity);
   }
 
-  async deleteByChannelId(channelId: bigint): Promise<boolean> {
+  async deleteByChannelId(channelId: string): Promise<boolean> {
     const result = await this.repository.deleteByChannelId(channelId);
     if (result) {
       this.cache.delete(channelId);

--- a/packages/application/src/services/ConfigurationServiceImpl.ts
+++ b/packages/application/src/services/ConfigurationServiceImpl.ts
@@ -27,12 +27,12 @@ export class ConfigurationServiceImpl implements ConfigurationService {
   ) {}
 
   async getConfiguration(
-    channelId: bigint,
+    channelId: string,
   ): Promise<ChannelConfiguration | undefined> {
     return this.channelConfigRepo.getByChannelId(channelId);
   }
 
-  async addTier(channelId: bigint, tier: Tier): Promise<AddTierResult> {
+  async addTier(channelId: string, tier: Tier): Promise<AddTierResult> {
     const channel = await this.channelConfigRepo.getByChannelId(channelId);
     if (!channel) {
       return AddTierResult.ChannelNotConnected;
@@ -49,7 +49,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
     return AddTierResult.Success;
   }
 
-  async removeTier(channelId: bigint, tier: Tier): Promise<RemoveTierResult> {
+  async removeTier(channelId: string, tier: Tier): Promise<RemoveTierResult> {
     const channel = await this.channelConfigRepo.getByChannelId(channelId);
     if (!channel) {
       return RemoveTierResult.ChannelNotConnected;
@@ -67,7 +67,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
   }
 
   async setPreferredLanguage(
-    channelId: bigint,
+    channelId: string,
     language: Language,
   ): Promise<SetPreferredLanguageResult> {
     const channel = await this.channelConfigRepo.getByChannelId(channelId);
@@ -85,7 +85,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
   }
 
   async setNotificationTimezone(
-    channelId: bigint,
+    channelId: string,
     timezone: Timezone,
   ): Promise<SetNotificationTimezoneResult> {
     const channel = await this.channelConfigRepo.getByChannelId(channelId);
@@ -103,7 +103,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
   }
 
   async enableDailyNotifications(
-    channelId: bigint,
+    channelId: string,
     enable: boolean,
   ): Promise<EnableDailyNotificationsResult> {
     const channel = await this.channelConfigRepo.getByChannelId(channelId);
@@ -130,7 +130,7 @@ export class ConfigurationServiceImpl implements ConfigurationService {
   }
 
   async setDailyNotificationTime(
-    channelId: bigint,
+    channelId: string,
     timeString: string,
   ): Promise<SetDailyNotificationTimeResult> {
     const channel = await this.channelConfigRepo.getByChannelId(channelId);

--- a/packages/application/src/services/ConnectionServiceImpl.ts
+++ b/packages/application/src/services/ConnectionServiceImpl.ts
@@ -51,4 +51,9 @@ export class ConnectionServiceImpl implements ConnectionService {
     await this.dailyNotificationScheduler.unschedule(channelId);
     return DisconnectionResult.Success;
   }
+
+  async disconnectAll(serverId: string): Promise<void> {
+    await this.channelConfigRepo.deleteByServerId(serverId);
+    // TODO: Clear daily notification schedules
+  }
 }

--- a/packages/application/src/services/ConnectionServiceImpl.ts
+++ b/packages/application/src/services/ConnectionServiceImpl.ts
@@ -1,4 +1,5 @@
 import { ChannelConfiguration } from "@dotabot.js/domain/ChannelConfiguration";
+import type { DailyNotificationScheduler } from "@dotabot.js/domain/notification/DailyNotificationScheduler";
 import type { ChannelConfigurationRepository } from "@dotabot.js/domain/repository/ChannelConfigurationRepository";
 import {
   ConnectionResult,
@@ -14,16 +15,21 @@ export class ConnectionServiceImpl implements ConnectionService {
     @inject(Symbols.ChannelConfigurationRepository)
     @named("cached")
     private channelConfigRepo: ChannelConfigurationRepository,
+    @inject(Symbols.DailyNotificationScheduler)
+    private dailyNotificationScheduler: DailyNotificationScheduler,
   ) {}
 
-  async connect(channelId: bigint): Promise<ConnectionResult> {
+  async connect(
+    channelId: string,
+    serverId: string,
+  ): Promise<ConnectionResult> {
     const existing = await this.channelConfigRepo.getByChannelId(channelId);
     if (existing) {
       return ConnectionResult.ChannelAlreadyConnected;
     }
 
     const result = await this.channelConfigRepo.create(
-      ChannelConfiguration.defaultNew(channelId),
+      ChannelConfiguration.defaultNew(channelId, serverId),
     );
     if (!result) {
       return ConnectionResult.UnknownError;
@@ -31,7 +37,7 @@ export class ConnectionServiceImpl implements ConnectionService {
     return ConnectionResult.Success;
   }
 
-  async disconnect(channelId: bigint): Promise<DisconnectionResult> {
+  async disconnect(channelId: string): Promise<DisconnectionResult> {
     const existing = await this.channelConfigRepo.getByChannelId(channelId);
     if (!existing) {
       return DisconnectionResult.ChannelNotConnected;
@@ -41,6 +47,8 @@ export class ConnectionServiceImpl implements ConnectionService {
     if (!result) {
       return DisconnectionResult.UnknownError;
     }
+    // Unschedule any potential daily notifications for this channel
+    await this.dailyNotificationScheduler.unschedule(channelId);
     return DisconnectionResult.Success;
   }
 }

--- a/packages/application/src/services/DailyMatchesNotificationServiceImpl.ts
+++ b/packages/application/src/services/DailyMatchesNotificationServiceImpl.ts
@@ -20,7 +20,7 @@ export class DailyMatchesNotificationServiceImpl implements DailyMatchesNotifica
     private readonly tournamentService: TournamentService,
   ) {}
 
-  async notify(channelId: bigint): Promise<void> {
+  async notify(channelId: string): Promise<void> {
     const channelConfig =
       await this.channelConfigRepo.getByChannelId(channelId);
     if (!channelConfig) {

--- a/packages/application/src/services/TournamentServiceImpl.ts
+++ b/packages/application/src/services/TournamentServiceImpl.ts
@@ -22,7 +22,7 @@ export class TournamentServiceImpl implements TournamentService {
   ) {}
 
   async getTournamentsWithMatchesToday(
-    channelId: bigint,
+    channelId: string,
     startTime: StartTime,
   ): Promise<GetTournamentsWithMatchesTodayResult> {
     const channel =

--- a/packages/application/src/services/TournamentServiceImpl.ts
+++ b/packages/application/src/services/TournamentServiceImpl.ts
@@ -41,7 +41,7 @@ export class TournamentServiceImpl implements TournamentService {
 
     switch (startTime) {
       case "Midnight":
-        earliestMatchStartTime = earliestMatchStartTime.startOf("day");
+        earliestMatchStartTime = earliestMatchStartTime.startOf("day").toUTC();
         break;
       case "DailyNotificationTime":
         if (!channel.dailyNotificationsEnabled) {
@@ -55,17 +55,16 @@ export class TournamentServiceImpl implements TournamentService {
             minute: channel.dailyNotificationTime!.minutes,
           },
           { zone },
-        );
+        ).toUTC();
         break;
     }
 
     const tournaments =
       await this.tournamentRepository.getTournamentsWithMatches({
-        earliestMatchStartTime: earliestMatchStartTime.toUTC(),
+        earliestMatchStartTime: earliestMatchStartTime,
         latestMatchStartTime: earliestMatchStartTime
           .plus({ days: 1 })
-          .minus({ seconds: 1 })
-          .toUTC(),
+          .minus({ seconds: 1 }),
         tiers: channel.tiers,
       });
 

--- a/packages/application/src/services/__tests__/TournamentServiceImpl.test.ts
+++ b/packages/application/src/services/__tests__/TournamentServiceImpl.test.ts
@@ -17,6 +17,7 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
     return {
       getByChannelId: repository.getByChannelId ?? vi.fn(),
       deleteByChannelId: repository.deleteByChannelId ?? vi.fn(),
+      deleteByServerId: repository.deleteByServerId ?? vi.fn(),
       getById: repository.getById ?? vi.fn(),
       create: repository.create ?? vi.fn(),
       update: repository.update ?? vi.fn(),
@@ -46,7 +47,10 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
     );
 
     // 2. Act
-    const result = await service.getTournamentsWithMatchesToday(0n, "Midnight");
+    const result = await service.getTournamentsWithMatchesToday(
+      "123456789",
+      "Midnight",
+    );
 
     // 3. Assert
     expect(result.status).toBe(
@@ -62,7 +66,8 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
         .mockResolvedValue(
           ChannelConfiguration.fromExisting(
             0,
-            0n,
+            "123456789",
+            "123456789",
             [],
             Timezone.GMT,
             Language.English,
@@ -79,7 +84,10 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
     );
 
     // 2. Act
-    const result = await service.getTournamentsWithMatchesToday(0n, "Midnight");
+    const result = await service.getTournamentsWithMatchesToday(
+      "123456789",
+      "Midnight",
+    );
 
     // 3. Assert
     expect(result.status).toBe(
@@ -95,7 +103,8 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
         .mockResolvedValue(
           ChannelConfiguration.fromExisting(
             0,
-            0n,
+            "123456789",
+            "123456789",
             [],
             Timezone.GMT,
             Language.English,
@@ -114,7 +123,10 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
     );
 
     // 2. Act
-    const result = await service.getTournamentsWithMatchesToday(0n, "Midnight");
+    const result = await service.getTournamentsWithMatchesToday(
+      "123456789",
+      "Midnight",
+    );
 
     // 3. Assert
     expect(result.status).toBe(
@@ -130,7 +142,8 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
       // 1. Arrange
       const channel = ChannelConfiguration.fromExisting(
         0,
-        0n,
+        "123456789",
+        "123456789",
         [],
         timezone,
         Language.English,
@@ -160,7 +173,7 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
         .toUTC();
 
       // 2. Act
-      await service.getTournamentsWithMatchesToday(0n, "Midnight");
+      await service.getTournamentsWithMatchesToday("123456789", "Midnight");
 
       // 3. Assert
       expect(
@@ -184,7 +197,8 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
       const dailyNotificationTime = new TimeOnly(10, 0);
       const channel = ChannelConfiguration.fromExisting(
         0,
-        0n,
+        "123456789",
+        "123456789",
         [],
         timezone,
         Language.English,
@@ -213,10 +227,13 @@ describe("TournamentService::getTournamentsWithMatchesToday", () => {
           zone: IANAZone.create(timezone),
         },
       ).toUTC();
-      const endTime = startTime.plus({ days: 1 }).minus({ seconds: 1 }).toUTC();
+      const endTime = startTime.plus({ days: 1 }).minus({ seconds: 1 });
 
       // 2. Act
-      await service.getTournamentsWithMatchesToday(0n, "DailyNotificationTime");
+      await service.getTournamentsWithMatchesToday(
+        "123456789",
+        "DailyNotificationTime",
+      );
 
       // 3. Assert
       expect(

--- a/packages/domain/src/ChannelConfiguration.ts
+++ b/packages/domain/src/ChannelConfiguration.ts
@@ -6,14 +6,16 @@ import { Timezone } from "./Timezone";
 
 export class ChannelConfiguration implements Entity {
   private _id?: number;
-  private _channelId: bigint;
+  private _channelId: string;
+  private _serverId: string;
   private _tiers: Tier[];
   private _timezone: Timezone;
   private _preferredLanguage: Language;
   private _dailyNotificationTime?: TimeOnly;
 
   constructor(
-    channelId: bigint,
+    channelId: string,
+    serverId: string,
     tiers: Tier[],
     timezone: Timezone,
     preferredLanguage: Language,
@@ -22,6 +24,7 @@ export class ChannelConfiguration implements Entity {
   ) {
     this._id = id;
     this._channelId = channelId;
+    this._serverId = serverId;
     this._tiers = tiers;
     this._timezone = timezone;
     this._preferredLanguage = preferredLanguage;
@@ -29,9 +32,13 @@ export class ChannelConfiguration implements Entity {
   }
 
   //#region Factory functions
-  static defaultNew(channelId: bigint): Omit<ChannelConfiguration, "id"> {
+  static defaultNew(
+    channelId: string,
+    serverId: string,
+  ): Omit<ChannelConfiguration, "id"> {
     return new ChannelConfiguration(
       channelId,
+      serverId,
       [Tier.S, Tier.A],
       Timezone.GMT,
       Language.English,
@@ -40,7 +47,8 @@ export class ChannelConfiguration implements Entity {
 
   static fromExisting(
     id: number,
-    channelId: bigint,
+    channelId: string,
+    serverId: string,
     tiers: Tier[],
     timezone: Timezone,
     preferredLanguage: Language,
@@ -48,6 +56,7 @@ export class ChannelConfiguration implements Entity {
   ): ChannelConfiguration {
     return new ChannelConfiguration(
       channelId,
+      serverId,
       tiers,
       timezone,
       preferredLanguage,
@@ -64,6 +73,10 @@ export class ChannelConfiguration implements Entity {
 
   public get channelId() {
     return this._channelId;
+  }
+
+  public get serverId() {
+    return this._serverId;
   }
 
   public get tiers() {

--- a/packages/domain/src/__tests__/ChannelConfiguration.test.ts
+++ b/packages/domain/src/__tests__/ChannelConfiguration.test.ts
@@ -10,7 +10,8 @@ describe("ChannelConfiguration tests", () => {
     // 1. Arrange
     const config = ChannelConfiguration.fromExisting(
       0,
-      0n,
+      "123456789",
+      "123456789",
       [Tier.S],
       Timezone.GMT,
       Language.English,
@@ -28,7 +29,8 @@ describe("ChannelConfiguration tests", () => {
     // 1. Arrange
     const config = ChannelConfiguration.fromExisting(
       0,
-      0n,
+      "123456789",
+      "123456789",
       [Tier.S],
       Timezone.GMT,
       Language.English,
@@ -45,7 +47,8 @@ describe("ChannelConfiguration tests", () => {
     // 1. Arrange
     const config = ChannelConfiguration.fromExisting(
       0,
-      0n,
+      "123456789",
+      "123456789",
       [Tier.S, Tier.A],
       Timezone.GMT,
       Language.English,
@@ -63,7 +66,8 @@ describe("ChannelConfiguration tests", () => {
     // 1. Arrange
     const config = ChannelConfiguration.fromExisting(
       0,
-      0n,
+      "123456789",
+      "123456789",
       [Tier.S],
       Timezone.GMT,
       Language.English,
@@ -86,7 +90,8 @@ describe("ChannelConfiguration tests", () => {
       // 1. Arrange
       const config = ChannelConfiguration.fromExisting(
         0,
-        0n,
+        "123456789",
+        "123456789",
         [Tier.S],
         Timezone.GMT,
         Language.English,
@@ -108,7 +113,8 @@ describe("ChannelConfiguration tests", () => {
       // 1. Arrange
       const config = ChannelConfiguration.fromExisting(
         0,
-        0n,
+        "123456789",
+        "123456789",
         [Tier.S],
         Timezone.GMT,
         Language.English,

--- a/packages/domain/src/cache/ChannelConfigurationCache.ts
+++ b/packages/domain/src/cache/ChannelConfigurationCache.ts
@@ -1,11 +1,11 @@
 import type { ChannelConfiguration } from "../ChannelConfiguration";
 
 export interface ChannelConfigurationCache {
-  get(channelId: bigint): ChannelConfiguration | undefined;
+  get(channelId: string): ChannelConfiguration | undefined;
   set(
-    channelId: bigint,
+    channelId: string,
     channelConfig: ChannelConfiguration,
     ttl?: number,
   ): void;
-  delete(channelId: bigint): void;
+  delete(channelId: string): void;
 }

--- a/packages/domain/src/notification/DailyNotificationScheduler.ts
+++ b/packages/domain/src/notification/DailyNotificationScheduler.ts
@@ -2,5 +2,5 @@ import type { ChannelConfiguration } from "../ChannelConfiguration";
 
 export interface DailyNotificationScheduler {
   schedule(channelConfig: ChannelConfiguration): Promise<void>;
-  unschedule(channelId: bigint): Promise<void>;
+  unschedule(channelId: string): Promise<void>;
 }

--- a/packages/domain/src/repository/ChannelConfigurationRepository.ts
+++ b/packages/domain/src/repository/ChannelConfigurationRepository.ts
@@ -4,4 +4,5 @@ import type { ChannelConfiguration } from "../ChannelConfiguration";
 export interface ChannelConfigurationRepository extends Repository<ChannelConfiguration> {
   getByChannelId(channelId: string): Promise<ChannelConfiguration | undefined>;
   deleteByChannelId(channelId: string): Promise<boolean>;
+  deleteByServerId(serverId: string): Promise<boolean>;
 }

--- a/packages/domain/src/repository/ChannelConfigurationRepository.ts
+++ b/packages/domain/src/repository/ChannelConfigurationRepository.ts
@@ -2,6 +2,6 @@ import type { Repository } from "./Repository";
 import type { ChannelConfiguration } from "../ChannelConfiguration";
 
 export interface ChannelConfigurationRepository extends Repository<ChannelConfiguration> {
-  getByChannelId(channelId: bigint): Promise<ChannelConfiguration | undefined>;
-  deleteByChannelId(channelId: bigint): Promise<boolean>;
+  getByChannelId(channelId: string): Promise<ChannelConfiguration | undefined>;
+  deleteByChannelId(channelId: string): Promise<boolean>;
 }

--- a/packages/domain/src/service/ConfigurationService.ts
+++ b/packages/domain/src/service/ConfigurationService.ts
@@ -45,32 +45,32 @@ export enum SetDailyNotificationTimeResult {
 export interface ConfigurationService {
   // Get configuration
   getConfiguration(
-    channelId: bigint,
+    channelId: string,
   ): Promise<ChannelConfiguration | undefined>;
 
   // Tier configuration
-  addTier(channelId: bigint, tier: Tier): Promise<AddTierResult>;
-  removeTier(channelId: bigint, tier: Tier): Promise<RemoveTierResult>;
+  addTier(channelId: string, tier: Tier): Promise<AddTierResult>;
+  removeTier(channelId: string, tier: Tier): Promise<RemoveTierResult>;
 
   // Language configuration
   setPreferredLanguage(
-    channelId: bigint,
+    channelId: string,
     language: Language,
   ): Promise<SetPreferredLanguageResult>;
 
   // Timezone configuration
   setNotificationTimezone(
-    channelId: bigint,
+    channelId: string,
     timezone: Timezone,
   ): Promise<SetNotificationTimezoneResult>;
 
   // Daily notification configuration
   enableDailyNotifications(
-    channelId: bigint,
+    channelId: string,
     enable: boolean,
   ): Promise<EnableDailyNotificationsResult>;
   setDailyNotificationTime(
-    channelId: bigint,
+    channelId: string,
     timeString: string,
   ): Promise<SetDailyNotificationTimeResult>;
 }

--- a/packages/domain/src/service/ConnectionService.ts
+++ b/packages/domain/src/service/ConnectionService.ts
@@ -11,6 +11,6 @@ export enum DisconnectionResult {
 }
 
 export interface ConnectionService {
-  connect(channelId: bigint): Promise<ConnectionResult>;
-  disconnect(channelId: bigint): Promise<DisconnectionResult>;
+  connect(channelId: string, serverId: string): Promise<ConnectionResult>;
+  disconnect(channelId: string): Promise<DisconnectionResult>;
 }

--- a/packages/domain/src/service/ConnectionService.ts
+++ b/packages/domain/src/service/ConnectionService.ts
@@ -13,4 +13,5 @@ export enum DisconnectionResult {
 export interface ConnectionService {
   connect(channelId: string, serverId: string): Promise<ConnectionResult>;
   disconnect(channelId: string): Promise<DisconnectionResult>;
+  disconnectAll(serverId: string): Promise<void>;
 }

--- a/packages/domain/src/service/DailyMatchesNotificationService.ts
+++ b/packages/domain/src/service/DailyMatchesNotificationService.ts
@@ -1,3 +1,3 @@
 export interface DailyMatchesNotificationService {
-  notify(channelId: bigint): Promise<void>;
+  notify(channelId: string): Promise<void>;
 }

--- a/packages/domain/src/service/TournamentService.ts
+++ b/packages/domain/src/service/TournamentService.ts
@@ -25,7 +25,7 @@ export type GetTournamentsWithMatchesTodayResult =
 
 export interface TournamentService {
   getTournamentsWithMatchesToday(
-    channelId: bigint,
+    channelId: string,
     startTime: StartTime,
   ): Promise<GetTournamentsWithMatchesTodayResult>;
 }

--- a/packages/infrastructure/database/prisma/migrations/20260326230921_change_channel_id_to_string_add_server_id/migration.sql
+++ b/packages/infrastructure/database/prisma/migrations/20260326230921_change_channel_id_to_string_add_server_id/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "bot"."channel_configurations" ADD COLUMN     "server_id" TEXT NOT NULL DEFAULT '',
+ALTER COLUMN "channel_id" SET DATA TYPE TEXT;
+
+-- CreateIndex
+CREATE INDEX "channel_configurations_server_id_idx" ON "bot"."channel_configurations"("server_id");

--- a/packages/infrastructure/database/prisma/schemas/bot.prisma
+++ b/packages/infrastructure/database/prisma/schemas/bot.prisma
@@ -51,7 +51,8 @@ enum Tier {
 model ChannelConfiguration {
     // Properties
     id                    Int       @id @default(autoincrement())
-    channelId             BigInt    @unique @map("channel_id")
+    channelId             String    @unique @map("channel_id")
+    serverId              String    @default("") @map("server_id")
     tiers                 Tier[]    @default([S, A])
     timezone              Timezone  @default(GMT)
     preferredLanguage     Language  @default(English) @map("preferred_language")
@@ -59,6 +60,7 @@ model ChannelConfiguration {
 
     // Indices
     @@index(channelId)
+    @@index(serverId)
     // Mapping
     @@map("channel_configurations")
     // Schema

--- a/packages/infrastructure/database/src/mappers/ChannelConfigurationMapper.ts
+++ b/packages/infrastructure/database/src/mappers/ChannelConfigurationMapper.ts
@@ -10,6 +10,7 @@ export class ChannelConfigurationMapper {
     return ChannelConfiguration.fromExisting(
       model.id,
       model.channelId,
+      model.serverId,
       model.tiers.map(TierMapper.toDomain),
       TimezoneMapper.toDomain(model.timezone),
       LanguageMapper.toDomain(model.preferredLanguage),
@@ -22,6 +23,7 @@ export class ChannelConfigurationMapper {
   ): Omit<ChannelConfigurationModel, "id"> {
     return {
       channelId: domain.channelId,
+      serverId: domain.serverId,
       tiers: domain.tiers.map(TierMapper.toModel),
       preferredLanguage: LanguageMapper.toModel(domain.preferredLanguage),
       timezone: TimezoneMapper.toModel(domain.timezone),
@@ -36,6 +38,7 @@ export class ChannelConfigurationMapper {
   ): Partial<Omit<ChannelConfigurationModel, "id">> {
     return {
       channelId: domain.channelId,
+      serverId: domain.serverId,
       tiers: domain.tiers?.map(TierMapper.toModel),
       preferredLanguage: domain.preferredLanguage
         ? LanguageMapper.toModel(domain.preferredLanguage)

--- a/packages/infrastructure/database/src/repositories/PrismaChannelConfigurationRepository.ts
+++ b/packages/infrastructure/database/src/repositories/PrismaChannelConfigurationRepository.ts
@@ -67,6 +67,17 @@ export class PrismaChannelConfigurationRepository implements ChannelConfiguratio
     }
   }
 
+  async deleteByServerId(serverId: string): Promise<boolean> {
+    try {
+      await prisma.channelConfiguration.deleteMany({
+        where: { serverId: serverId },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async delete(id: number): Promise<boolean> {
     try {
       await prisma.channelConfiguration.delete({

--- a/packages/infrastructure/database/src/repositories/PrismaChannelConfigurationRepository.ts
+++ b/packages/infrastructure/database/src/repositories/PrismaChannelConfigurationRepository.ts
@@ -7,7 +7,7 @@ import prisma from "../prisma";
 @injectable()
 export class PrismaChannelConfigurationRepository implements ChannelConfigurationRepository {
   async getByChannelId(
-    channelId: bigint,
+    channelId: string,
   ): Promise<ChannelConfiguration | undefined> {
     const channelConfig = await prisma.channelConfiguration.findUnique({
       where: { channelId: channelId },
@@ -56,7 +56,7 @@ export class PrismaChannelConfigurationRepository implements ChannelConfiguratio
     return true;
   }
 
-  async deleteByChannelId(channelId: bigint): Promise<boolean> {
+  async deleteByChannelId(channelId: string): Promise<boolean> {
     try {
       await prisma.channelConfiguration.delete({
         where: { channelId: channelId },

--- a/packages/infrastructure/notifications.bullmq/src/schedulers/BullDailyNotificationScheduler.ts
+++ b/packages/infrastructure/notifications.bullmq/src/schedulers/BullDailyNotificationScheduler.ts
@@ -47,10 +47,10 @@ export class BullDailyNotificationScheduler implements DailyNotificationSchedule
     );
   }
 
-  async unschedule(channelId: bigint): Promise<void> {
+  async unschedule(channelId: string): Promise<void> {
     const jobId = this.buildJobId(channelId);
     await this.queue.removeJobScheduler(jobId);
   }
 
-  private buildJobId = (channelId: bigint) => `daily-notification-${channelId}`;
+  private buildJobId = (channelId: string) => `daily-notification-${channelId}`;
 }

--- a/packages/infrastructure/notifications.bullmq/src/schedulers/workers/DailyNotificationWorker.ts
+++ b/packages/infrastructure/notifications.bullmq/src/schedulers/workers/DailyNotificationWorker.ts
@@ -15,7 +15,7 @@ export class DailyNotificationWorker {
         if (!job.data.channelId) {
           throw new Error("No channel ID specified");
         }
-        const channelId = BigInt(job.data.channelId);
+        const channelId = job.data.channelId;
         await notificationsService.notify(channelId);
       },
       {

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
     "globalEnv": [
         "DATABASE_URL",
         "DISCORD_TOKEN",
-        "PANDASCORE_TOKEN"
+        "PANDASCORE_TOKEN",
+        "GUILD_ID"
     ],
     "tasks": {
         "build": {


### PR DESCRIPTION
Transitions match listings from traditional Embeds to the new Discord Message Components layout using ContainerBuilder. 
This change also updates the bot initialization to support guild-specific command registration.