### PR TITLE
Pass channel ID as string to configuration service

### DIFF
--- a/apps/discord/src/commands/notify/notify.ts
+++ b/apps/discord/src/commands/notify/notify.ts
@@ -80,9 +80,8 @@ export class NotifyCommand extends Subcommand {
       return;
     }
 
-    const channelId = BigInt(interaction.channelId);
     const result = await this._configurationService.enableDailyNotifications(
-      channelId,
+      interaction.channelId,
       enabled,
     );
 
@@ -121,9 +120,8 @@ export class NotifyCommand extends Subcommand {
       return;
     }
 
-    const channelId = BigInt(interaction.channelId);
     const result = await this._configurationService.setDailyNotificationTime(
-      channelId,
+      interaction.channelId,
       timeString,
     );
 


### PR DESCRIPTION
Fixes a build error by removing the unnecessary BigInt conversion for interaction channel IDs.